### PR TITLE
Upgrades to the new NR API

### DIFF
--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -8,12 +8,11 @@ properties:
   api_key:
     type: string
     required: true
-  app_name:
+  app_id:
     type: string
     required: true
-  skip:
+  on:
     type: string
-    default: true
     required: false
   revision:
     type: string


### PR DESCRIPTION
- Also shifts to the new NR API (v2)
- Shifts from the skip param to a on param
- The old has been deprecated and docs are no longer available
- Adds a new mandatory app_id parameter as per the new API docs
- Adds support for USER info being passed to NR